### PR TITLE
feat: include AI-generated recap text in race recap API response

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -61,7 +61,11 @@ service cloud.firestore {
     // Read-only for the client apps. Only admins (handled via backend scripts) can write.
     match /drivers/{driverId} {
       allow read: if isSignedIn();
-      allow write: if false; 
+      allow write: if false;
+    }
+    match /driver_summaries/{driverId} {
+      allow read: if isSignedIn();
+      allow write: if false;
     }
     
     // 4. RACES & 4a. DRIVER SCORES

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsController.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsController.kt
@@ -63,8 +63,18 @@ class AdminOperationsController(
     @PostMapping("/race-weekends/recap")
     suspend fun generateRaceRecaps(@RequestBody request: GenerateRaceRecapRequest): GenerateRaceRecapResponse {
         try {
-            val recapIds = raceWeekendService.generateRaceRecap(request.raceIds)
-            return GenerateRaceRecapResponse(recapIds)
+            val recaps = raceWeekendService.generateRaceRecap(request.raceIds)
+            val recapEntries = recaps.map {
+                GenerateRaceRecapResponse.RecapEntry(
+                    raceId = it.raceId,
+                    raceName = it.raceName,
+                    recapParagraphs = it.recapParagraphs
+                )
+            }
+            return GenerateRaceRecapResponse(
+                recapIds = recaps.map { it.raceId },
+                recaps = recapEntries
+            )
         } catch (e: Exception) {
             LOGGER.error("Failed to generate race recaps", e)
             throw RuntimeException(e.message)

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsController.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsController.kt
@@ -1,9 +1,11 @@
 package net.battaglini.fantaf1appbackend.controller
 
+import net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest
 import net.battaglini.fantaf1appbackend.model.request.UpdateDriversPricesRequest
 import net.battaglini.fantaf1appbackend.model.request.UpdateDriversSummariesRequest
 import net.battaglini.fantaf1appbackend.model.response.DriverPriceUpdateResponse
 import net.battaglini.fantaf1appbackend.model.response.DriverSummariesResponse
+import net.battaglini.fantaf1appbackend.model.response.GenerateRaceRecapResponse
 import net.battaglini.fantaf1appbackend.service.DriverPricingService
 import net.battaglini.fantaf1appbackend.service.DriverService
 import net.battaglini.fantaf1appbackend.service.RaceWeekendService
@@ -54,6 +56,17 @@ class AdminOperationsController(
             return DriverPriceUpdateResponse(updates)
         } catch (e: Exception) {
             LOGGER.error("Failed to manually update driver prices", e)
+            throw RuntimeException(e.message)
+        }
+    }
+
+    @PostMapping("/race-weekends/recap")
+    suspend fun generateRaceRecaps(@RequestBody request: GenerateRaceRecapRequest): GenerateRaceRecapResponse {
+        try {
+            val recapIds = raceWeekendService.generateRaceRecap(request.raceIds)
+            return GenerateRaceRecapResponse(recapIds)
+        } catch (e: Exception) {
+            LOGGER.error("Failed to generate race recaps", e)
             throw RuntimeException(e.message)
         }
     }

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/model/RaceWeekendRecap.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/model/RaceWeekendRecap.kt
@@ -1,0 +1,7 @@
+package net.battaglini.fantaf1appbackend.model
+
+data class RaceWeekendRecap(
+    val raceId: String,
+    val raceName: String,
+    val recapParagraphs: List<String>
+)

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/model/RaceWeekendResult.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/model/RaceWeekendResult.kt
@@ -17,8 +17,7 @@ data class RaceWeekendResult(
     @JsonDeserialize(using = KotlinInstantDeserializer::class)
     val updatedAt: Instant,
     val version: Int,
-    val results: List<Result>,
-    val summaryParagraphs: List<String>?
+    val results: List<Result>
 ) {
     override fun toString(): String {
         return """

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/model/request/GenerateRaceRecapRequest.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/model/request/GenerateRaceRecapRequest.kt
@@ -1,0 +1,5 @@
+package net.battaglini.fantaf1appbackend.model.request
+
+data class GenerateRaceRecapRequest(
+    val raceIds: List<String>
+)

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/model/response/GenerateRaceRecapResponse.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/model/response/GenerateRaceRecapResponse.kt
@@ -1,0 +1,5 @@
+package net.battaglini.fantaf1appbackend.model.response
+
+data class GenerateRaceRecapResponse(
+    val recapIds: List<String>
+)

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/model/response/GenerateRaceRecapResponse.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/model/response/GenerateRaceRecapResponse.kt
@@ -1,5 +1,12 @@
 package net.battaglini.fantaf1appbackend.model.response
 
 data class GenerateRaceRecapResponse(
-    val recapIds: List<String>
-)
+    val recapIds: List<String>,
+    val recaps: List<RecapEntry>
+) {
+    data class RecapEntry(
+        val raceId: String,
+        val raceName: String,
+        val recapParagraphs: List<String>
+    )
+}

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/repository/RaceRepository.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/repository/RaceRepository.kt
@@ -4,6 +4,8 @@ import com.google.cloud.firestore.Firestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -58,6 +60,19 @@ class RaceRepository(
                 .whereLessThanOrEqualTo(RaceWeekend::dateEnd.name, endOfYearTimestamp)
                 .get().get()
         }.map { objectMapper.convertValue(it.data, RaceWeekend::class.java) }.asFlow()
+    }
+
+    suspend fun getRaceById(raceId: String): Flow<RaceWeekend> {
+        return withContext(Dispatchers.IO) {
+            val document = firestore.collection(COLLECTION_PATH).document(raceId).get().get()
+            if (document.exists()) {
+                flow {
+                    emit(objectMapper.convertValue(document.data, RaceWeekend::class.java))
+                }
+            } else {
+                emptyFlow()
+            }
+        }
     }
 
     companion object {

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/repository/RaceWeekendRecapRepository.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/repository/RaceWeekendRecapRepository.kt
@@ -1,0 +1,29 @@
+package net.battaglini.fantaf1appbackend.repository
+
+import com.google.cloud.firestore.Firestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.battaglini.fantaf1appbackend.model.RaceWeekendRecap
+import org.springframework.stereotype.Repository
+import tools.jackson.databind.ObjectMapper
+
+@Repository
+class RaceWeekendRecapRepository(
+    private val firestore: Firestore,
+    private val objectMapper: ObjectMapper
+) {
+    suspend fun saveRaceWeekendRecap(recap: RaceWeekendRecap) {
+        withContext(Dispatchers.IO) {
+            firestore.collection(COLLECTION_PATH).document(recap.raceId).set(
+                objectMapper.convertValue(
+                    recap,
+                    Map::class.java
+                ).orEmpty()
+            ).get()
+        }
+    }
+
+    companion object {
+        private const val COLLECTION_PATH = "race_weekend_recaps"
+    }
+}

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/GenAIServiceImpl.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/GenAIServiceImpl.kt
@@ -26,7 +26,7 @@ class GenAIServiceImpl(
                     averageScore
                 )
             }.",
-            "Use markdown formatting."
+            "Use markdown formatting. The sentence about the idgaf-1 score should be bold"
         )
 
         return genAIClient.generateContentNoThinking(
@@ -36,14 +36,18 @@ class GenAIServiceImpl(
     }
 
     override suspend fun generateRaceRecap(raceName: String): Flow<String> {
+        val year = clock.now().toLocalDateTime(timeZone).year
         val instructions = listOf(
             "You are a sports journalist.",
             "You're writing a quick summary of a Formula 1 Grand Prix.",
             "Consider the entire weekend (free practice, qualifying, etc.), not just the actual race.",
+            "If the race weekend included Sprint qualifying and Sprint race, include those int the recap as well",
+            "Use the google search tool to find the latest information about the race.",
             "Mention the weather conditions.",
-            "Mention which teams and drivers did best and which did worst."
+            "Mention which teams and drivers did best and which did worst.",
+            "Use markdown formatting."
         )
 
-        return genAIClient.generateContentNoThinking("Give me a recap of the $raceName", instructions)
+        return genAIClient.generateContentNoThinking("Give me a recap of the $year $raceName", instructions)
     }
 }

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendService.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendService.kt
@@ -8,4 +8,13 @@ interface RaceWeekendService {
      * Fetches current year's race weekend schedule and seeds it into the repository.
      */
     suspend fun seedRaceWeekends()
+
+    /**
+     * Generates AI race recaps for the given race IDs.
+     * Each recap is generated via GenAI and saved to Firestore.
+     *
+     * @param raceIds list of race IDs to generate recaps for
+     * @return list of race IDs that were successfully processed
+     */
+    suspend fun generateRaceRecap(raceIds: List<String>): List<String>
 }

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendService.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendService.kt
@@ -14,7 +14,7 @@ interface RaceWeekendService {
      * Each recap is generated via GenAI and saved to Firestore.
      *
      * @param raceIds list of race IDs to generate recaps for
-     * @return list of race IDs that were successfully processed
+     * @return list of successfully processed race recaps with generated content
      */
-    suspend fun generateRaceRecap(raceIds: List<String>): List<String>
+    suspend fun generateRaceRecap(raceIds: List<String>): List<net.battaglini.fantaf1appbackend.model.RaceWeekendRecap>
 }

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
@@ -1,15 +1,18 @@
 package net.battaglini.fantaf1appbackend.service
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import net.battaglini.fantaf1appbackend.client.OpenF1Client
 import net.battaglini.fantaf1appbackend.configuration.SeedingProperties
+import net.battaglini.fantaf1appbackend.model.RaceWeekendRecap
 import net.battaglini.fantaf1appbackend.model.openf1.OpenF1MeetingResponse.Companion.toRace
 import net.battaglini.fantaf1appbackend.model.openf1.OpenF1SessionResponse.Companion.toRaceWeekendSession
 import net.battaglini.fantaf1appbackend.repository.RaceRepository
+import net.battaglini.fantaf1appbackend.repository.RaceWeekendRecapRepository
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
@@ -26,6 +29,8 @@ class RaceWeekendServiceImpl(
     private val openF1Client: OpenF1Client,
     private val raceRepository: RaceRepository,
     private val seedingProperties: SeedingProperties,
+    private val genAIService: GenAIService,
+    private val raceWeekendRecapRepository: RaceWeekendRecapRepository,
     private val clock: Clock,
     private val timeZone: TimeZone
 ) : RaceWeekendService {
@@ -55,6 +60,34 @@ class RaceWeekendServiceImpl(
         } catch (e: Exception) {
             LOGGER.error("Error seeding race weekends into Firebase", e)
         }
+    }
+
+    override suspend fun generateRaceRecap(raceIds: List<String>): List<String> {
+        val processedIds = mutableListOf<String>()
+
+        for (raceId in raceIds) {
+            try {
+                val race = raceRepository.getRaceById(raceId).first()
+
+                val recapFlow = genAIService.generateRaceRecap(race.raceName)
+                val paragraphs = recapFlow.toList()
+
+                val recap = RaceWeekendRecap(
+                    raceId = raceId,
+                    raceName = race.raceName,
+                    recapParagraphs = paragraphs
+                )
+
+                raceWeekendRecapRepository.saveRaceWeekendRecap(recap)
+                processedIds.add(raceId)
+
+                LOGGER.info("Generated race recap for $raceId ($race.raceName)")
+            } catch (e: Exception) {
+                LOGGER.error("Failed to generate race recap for $raceId", e)
+            }
+        }
+
+        return processedIds
     }
 
     private fun calculateRaceId(meetingKey: Int, year: Int): String {

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
@@ -62,8 +62,8 @@ class RaceWeekendServiceImpl(
         }
     }
 
-    override suspend fun generateRaceRecap(raceIds: List<String>): List<String> {
-        val processedIds = mutableListOf<String>()
+    override suspend fun generateRaceRecap(raceIds: List<String>): List<RaceWeekendRecap> {
+        val processedRecaps = mutableListOf<RaceWeekendRecap>()
 
         for (raceId in raceIds) {
             try {
@@ -79,7 +79,7 @@ class RaceWeekendServiceImpl(
                 )
 
                 raceWeekendRecapRepository.saveRaceWeekendRecap(recap)
-                processedIds.add(raceId)
+                processedRecaps.add(recap)
 
                 LOGGER.info("Generated race recap for $raceId ($race.raceName)")
             } catch (e: Exception) {
@@ -87,7 +87,7 @@ class RaceWeekendServiceImpl(
             }
         }
 
-        return processedIds
+        return processedRecaps
     }
 
     private fun calculateRaceId(meetingKey: Int, year: Int): String {

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/task/RaceWeekendResultsCalculatorTask.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/task/RaceWeekendResultsCalculatorTask.kt
@@ -188,8 +188,7 @@ class RaceWeekendResultsCalculatorTask(
             createdAt = clock.now(),
             updatedAt = clock.now(),
             version = 1,
-            results = results,
-            summaryParagraphs = null
+            results = results
         )
     }
 

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsControllerTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsControllerTest.kt
@@ -140,4 +140,67 @@ class AdminOperationsControllerTest {
             .exchange()
             .expectStatus().is5xxServerError
     }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `generateRaceRecaps should return 200 OK when successful`() {
+        val request = net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest(
+            raceIds = listOf("race-1", "race-2")
+        )
+        coEvery { raceWeekendService.generateRaceRecap(any()) } returns listOf("race-1", "race-2")
+
+        webTestClient
+            .mutateWith(csrf())
+            .post()
+            .uri("/admin/race-weekends/recap")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.recapIds").isArray
+            .jsonPath("$.recapIds.length()").isEqualTo(2)
+            .jsonPath("$.recapIds[0]").isEqualTo("race-1")
+            .jsonPath("$.recapIds[1]").isEqualTo("race-2")
+
+        coVerify { raceWeekendService.generateRaceRecap(listOf("race-1", "race-2")) }
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `generateRaceRecaps should return 500 when service fails`() {
+        val request = net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest(
+            raceIds = listOf("race-1")
+        )
+        coEvery { raceWeekendService.generateRaceRecap(any()) } throws RuntimeException("GenAI error")
+
+        webTestClient
+            .mutateWith(csrf())
+            .post()
+            .uri("/admin/race-weekends/recap")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().is5xxServerError
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `generateRaceRecaps should return empty recapIds when no races processed`() {
+        val request = net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest(
+            raceIds = listOf("nonexistent")
+        )
+        coEvery { raceWeekendService.generateRaceRecap(any()) } returns emptyList()
+
+        webTestClient
+            .mutateWith(csrf())
+            .post()
+            .uri("/admin/race-weekends/recap")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.recapIds").isEmpty
+    }
 }

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsControllerTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/controller/AdminOperationsControllerTest.kt
@@ -147,7 +147,11 @@ class AdminOperationsControllerTest {
         val request = net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest(
             raceIds = listOf("race-1", "race-2")
         )
-        coEvery { raceWeekendService.generateRaceRecap(any()) } returns listOf("race-1", "race-2")
+        val mockRecaps = listOf(
+            net.battaglini.fantaf1appbackend.model.RaceWeekendRecap("race-1", "Monaco Grand Prix", listOf("Para 1", "Para 2")),
+            net.battaglini.fantaf1appbackend.model.RaceWeekendRecap("race-2", "British Grand Prix", listOf("Para A"))
+        )
+        coEvery { raceWeekendService.generateRaceRecap(any()) } returns mockRecaps
 
         webTestClient
             .mutateWith(csrf())
@@ -162,6 +166,14 @@ class AdminOperationsControllerTest {
             .jsonPath("$.recapIds.length()").isEqualTo(2)
             .jsonPath("$.recapIds[0]").isEqualTo("race-1")
             .jsonPath("$.recapIds[1]").isEqualTo("race-2")
+            .jsonPath("$.recaps").isArray
+            .jsonPath("$.recaps.length()").isEqualTo(2)
+            .jsonPath("$.recaps[0].raceId").isEqualTo("race-1")
+            .jsonPath("$.recaps[0].raceName").isEqualTo("Monaco Grand Prix")
+            .jsonPath("$.recaps[0].recapParagraphs").isArray
+            .jsonPath("$.recaps[0].recapParagraphs.length()").isEqualTo(2)
+            .jsonPath("$.recaps[1].raceId").isEqualTo("race-2")
+            .jsonPath("$.recaps[1].raceName").isEqualTo("British Grand Prix")
 
         coVerify { raceWeekendService.generateRaceRecap(listOf("race-1", "race-2")) }
     }
@@ -184,9 +196,9 @@ class AdminOperationsControllerTest {
             .expectStatus().is5xxServerError
     }
 
-    @Test
+   @Test
     @WithMockUser(roles = ["ADMIN"])
-    fun `generateRaceRecaps should return empty recapIds when no races processed`() {
+    fun `generateRaceRecaps should return empty recapIds and recaps when no races processed`() {
         val request = net.battaglini.fantaf1appbackend.model.request.GenerateRaceRecapRequest(
             raceIds = listOf("nonexistent")
         )
@@ -202,5 +214,6 @@ class AdminOperationsControllerTest {
             .expectStatus().isOk
             .expectBody()
             .jsonPath("$.recapIds").isEmpty
+            .jsonPath("$.recaps").isEmpty
     }
 }

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverPricingServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverPricingServiceTest.kt
@@ -57,15 +57,15 @@ class DriverPricingServiceTest {
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 10.0),
             RaceWeekendResult.Companion.Result("d2", 2, "PER", 5.0)
-        ), null)
+        ))
         val res2 = RaceWeekendResult("r2", "GP2", 102, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 15.0),
             RaceWeekendResult.Companion.Result("d2", 2, "PER", 5.0)
-        ), null)
+        ))
         val res3 = RaceWeekendResult("r3", "GP3", 103, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 20.0),
             RaceWeekendResult.Companion.Result("d2", 2, "PER", 10.0)
-        ), null)
+        ))
 
         coEvery { driverRepository.getDrivers() } returns activeDrivers.asFlow()
         coEvery { raceRepository.getRacesByYear(year) } returns allRaces.asFlow()
@@ -110,7 +110,7 @@ class DriverPricingServiceTest {
 
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 10.0)
-        ), null)
+        ))
 
         coEvery { driverRepository.getDrivers() } returns activeDrivers.asFlow()
         coEvery { raceRepository.getRacesByYear(year) } returns allRaces.asFlow()
@@ -145,7 +145,7 @@ class DriverPricingServiceTest {
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 20.0),
             RaceWeekendResult.Companion.Result("d2", 2, "PER", 20.0)
-        ), null)
+        ))
 
         coEvery { driverRepository.getDrivers() } returns activeDrivers.asFlow()
         coEvery { raceRepository.getRacesByYear(year) } returns allRaces.asFlow()
@@ -179,13 +179,13 @@ class DriverPricingServiceTest {
 
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 20.0)
-        ), null)
+        ))
         val res2 = RaceWeekendResult("r2", "GP2", 102, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 10.0)
-        ), null)
+        ))
         val res3 = RaceWeekendResult("r3", "GP3", 103, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 18.0)
-        ), null)
+        ))
 
         val previousCost = 75.0
         coEvery { driverRepository.getDrivers() } returns activeDrivers.asFlow()
@@ -219,7 +219,7 @@ class DriverPricingServiceTest {
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 20.0),
             RaceWeekendResult.Companion.Result("d2", 2, "HAM", 20.0)
-        ), null)
+        ))
 
         val localProperties = pricingProperties.copy(maxAvgPriceThreshold = 52.0)
         val localService = DriverPricingServiceImpl(
@@ -262,7 +262,7 @@ class DriverPricingServiceTest {
         val res1 = RaceWeekendResult("r1", "GP1", 101, kotlin.time.Clock.System.now(), kotlin.time.Clock.System.now(), 1, listOf(
             RaceWeekendResult.Companion.Result("d1", 1, "VER", 20.0),
             RaceWeekendResult.Companion.Result("d2", 2, "HAM", 0.0)
-        ), null)
+        ))
 
         // HAM already has high price, which pushes grid avg up
         val currentCosts = listOf(

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverServiceTest.kt
@@ -127,8 +127,7 @@ class DriverServiceTest {
         createdAt = Clock.System.now(),
         updatedAt = Clock.System.now(),
         version = 1,
-        results = listOf(RaceWeekendResult.Companion.Result(driverId, 1, "VER", points)),
-        summaryParagraphs = null
+        results = listOf(RaceWeekendResult.Companion.Result(driverId, 1, "VER", points))
     )
 
     @Test

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/GenAIServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/GenAIServiceTest.kt
@@ -49,7 +49,7 @@ class GenAIServiceTest {
             "Keep it brief and on point, maximum 40 words, excluding articles and conjunctions.",
             "Add a paragraph talking about how the formula 1 team for which they race is performing in the 2025 season.",
             "Add a sentence mentioning that the driver's average score in the IDGAF-1 app is 25.0.",
-            "Use markdown formatting."
+            "Use markdown formatting. The sentence about the idgaf-1 score should be bold"
         )
 
         coEvery { genAIClient.generateContentNoThinking(any(), any()) } returns flowOf("Generated summary")
@@ -113,6 +113,7 @@ class GenAIServiceTest {
 
     @Test
     fun `generateRaceRecap should construct prompt with race name`() = runTest {
+        every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
         coEvery { genAIClient.generateContentNoThinking(any(), any()) } returns flowOf("Race recap content")
 
         genAIService.generateRaceRecap("Monaco Grand Prix").toList()
@@ -120,19 +121,23 @@ class GenAIServiceTest {
         coVerify {
             genAIClient.generateContentNoThinking(withArg { prompt ->
                 assertTrue(prompt.contains("Monaco Grand Prix"), "Prompt should contain race name")
-                assertEquals("Give me a recap of the Monaco Grand Prix", prompt)
+                assertEquals("Give me a recap of the 2025 Monaco Grand Prix", prompt)
             }, any())
         }
     }
 
     @Test
     fun `generateRaceRecap should include correct instructions list`() = runTest {
+        every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
         val expectedInstructions = listOf(
             "You are a sports journalist.",
             "You're writing a quick summary of a Formula 1 Grand Prix.",
             "Consider the entire weekend (free practice, qualifying, etc.), not just the actual race.",
+            "If the race weekend included Sprint qualifying and Sprint race, include those int the recap as well",
+            "Use the google search tool to find the latest information about the race.",
             "Mention the weather conditions.",
-            "Mention which teams and drivers did best and which did worst."
+            "Mention which teams and drivers did best and which did worst.",
+            "Use markdown formatting."
         )
 
         coEvery { genAIClient.generateContentNoThinking(any(), any()) } returns flowOf("Recap")
@@ -163,6 +168,7 @@ class GenAIServiceTest {
 
     @Test
     fun `generateRaceRecap should delegate to client even with empty race name`() = runTest {
+        every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
         // No validation on race name — empty string should still delegate
         coEvery { genAIClient.generateContentNoThinking(any(), any()) } returns flowOf("Empty recap")
 
@@ -170,6 +176,6 @@ class GenAIServiceTest {
 
         assertEquals(1, result.size)
         assertEquals("Empty recap", result[0])
-        coVerify { genAIClient.generateContentNoThinking("Give me a recap of the ", any<List<String>>()) }
+        coVerify { genAIClient.generateContentNoThinking("Give me a recap of the 2025 ", any<List<String>>()) }
     }
 }

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/NotificationServiceTest.kt
@@ -63,8 +63,7 @@ class NotificationServiceTest {
         createdAt = Clock.System.now(),
         updatedAt = Clock.System.now(),
         version = 1,
-        results = emptyList(),
-        summaryParagraphs = null
+        results = emptyList()
     )
 
     private fun createRaceWeekend() = net.battaglini.fantaf1appbackend.model.RaceWeekend(

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
@@ -264,7 +264,9 @@ class RaceWeekendServiceTest {
         val result = raceWeekendService.generateRaceRecap(listOf("race-1"))
 
         assertEquals(1, result.size)
-        assertEquals("race-1", result[0])
+        assertEquals("race-1", result[0].raceId)
+        assertEquals("Monaco Grand Prix", result[0].raceName)
+        assertEquals(2, result[0].recapParagraphs.size)
         coVerify { genAIService.generateRaceRecap("Monaco Grand Prix") }
         coVerify { raceWeekendRecapRepository.saveRaceWeekendRecap(withArg { recap ->
             assertEquals("race-1", recap.raceId)
@@ -287,8 +289,8 @@ class RaceWeekendServiceTest {
         val result = raceWeekendService.generateRaceRecap(listOf("race-1", "race-2"))
 
         assertEquals(2, result.size)
-        assertTrue(result.contains("race-1"))
-        assertTrue(result.contains("race-2"))
+        assertTrue(result.any { it.raceId == "race-1" })
+        assertTrue(result.any { it.raceId == "race-2" })
         coVerify { genAIService.generateRaceRecap("Monaco Grand Prix") }
         coVerify { genAIService.generateRaceRecap("British Grand Prix") }
     }
@@ -316,7 +318,7 @@ class RaceWeekendServiceTest {
         val result = raceWeekendService.generateRaceRecap(listOf("race-1", "race-2"))
 
         assertEquals(1, result.size)
-        assertEquals("race-2", result[0])
+        assertEquals("race-2", result[0].raceId)
     }
 
     @Test

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
@@ -16,6 +16,7 @@ import net.battaglini.fantaf1appbackend.model.RaceWeekend
 import net.battaglini.fantaf1appbackend.model.openf1.OpenF1MeetingResponse
 import net.battaglini.fantaf1appbackend.model.openf1.OpenF1SessionResponse
 import net.battaglini.fantaf1appbackend.repository.RaceRepository
+import net.battaglini.fantaf1appbackend.repository.RaceWeekendRecapRepository
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,6 +37,12 @@ class RaceWeekendServiceTest {
 
     @MockK
     lateinit var seedingProperties: SeedingProperties
+
+    @MockK
+    lateinit var genAIService: GenAIService
+
+    @MockK
+    lateinit var raceWeekendRecapRepository: RaceWeekendRecapRepository
 
     @MockK
     lateinit var clock: Clock
@@ -82,6 +89,25 @@ class RaceWeekendServiceTest {
         dateEnd = kotlinx.datetime.LocalDateTime(2025, 3, 15, 13, 0, 0),
         gmtOffset = kotlinx.datetime.UtcOffset(4),
         year = 2025
+    )
+
+    private fun createRaceWeekend(
+        raceId: String = "race-1",
+        raceName: String = "Monaco Grand Prix",
+        openF1MeetingKey: Int = 100
+    ) = RaceWeekend(
+        raceId = raceId,
+        openF1MeetingKey = openF1MeetingKey,
+        raceName = raceName,
+        dateStart = Instant.parse("2025-05-24T12:00:00Z"),
+        dateEnd = Instant.parse("2025-05-25T16:00:00Z"),
+        sessions = emptyList(),
+        circuitImage = "circuit.png",
+        countryName = "Monaco",
+        countryFlag = "🇲🇨",
+        circuitType = "street",
+        dateLineupOpen = Instant.parse("2025-05-23T12:00:00Z"),
+        dateLineupClose = Instant.parse("2025-05-24T10:00:00Z")
     )
 
     @Test
@@ -222,5 +248,83 @@ class RaceWeekendServiceTest {
         raceWeekendService.seedRaceWeekends()
 
         coVerify { raceRepository.createOrUpdateRaces(any()) }
+    }
+
+    @Test
+    fun `generateRaceRecap should generate and save recap for single race`() = runTest {
+        val race = createRaceWeekend(raceId = "race-1", raceName = "Monaco Grand Prix", openF1MeetingKey = 100)
+
+        coEvery { raceRepository.getRaceById("race-1") } returns flowOf(race)
+        coEvery { genAIService.generateRaceRecap("Monaco Grand Prix") } returns flowOf(
+            "Paragraph 1",
+            "Paragraph 2"
+        )
+        coEvery { raceWeekendRecapRepository.saveRaceWeekendRecap(any()) } just Runs
+
+        val result = raceWeekendService.generateRaceRecap(listOf("race-1"))
+
+        assertEquals(1, result.size)
+        assertEquals("race-1", result[0])
+        coVerify { genAIService.generateRaceRecap("Monaco Grand Prix") }
+        coVerify { raceWeekendRecapRepository.saveRaceWeekendRecap(withArg { recap ->
+            assertEquals("race-1", recap.raceId)
+            assertEquals("Monaco Grand Prix", recap.raceName)
+            assertEquals(2, recap.recapParagraphs.size)
+        }) }
+    }
+
+    @Test
+    fun `generateRaceRecap should process multiple races`() = runTest {
+        val race1 = createRaceWeekend(raceId = "race-1", raceName = "Monaco Grand Prix", openF1MeetingKey = 100)
+        val race2 = createRaceWeekend(raceId = "race-2", raceName = "British Grand Prix", openF1MeetingKey = 200)
+
+        coEvery { raceRepository.getRaceById("race-1") } returns flowOf(race1)
+        coEvery { raceRepository.getRaceById("race-2") } returns flowOf(race2)
+        coEvery { genAIService.generateRaceRecap("Monaco Grand Prix") } returns flowOf("Recap Monaco")
+        coEvery { genAIService.generateRaceRecap("British Grand Prix") } returns flowOf("Recap Britain")
+        coEvery { raceWeekendRecapRepository.saveRaceWeekendRecap(any()) } just Runs
+
+        val result = raceWeekendService.generateRaceRecap(listOf("race-1", "race-2"))
+
+        assertEquals(2, result.size)
+        assertTrue(result.contains("race-1"))
+        assertTrue(result.contains("race-2"))
+        coVerify { genAIService.generateRaceRecap("Monaco Grand Prix") }
+        coVerify { genAIService.generateRaceRecap("British Grand Prix") }
+    }
+
+    @Test
+    fun `generateRaceRecap should skip races that are not found`() = runTest {
+        coEvery { raceRepository.getRaceById("nonexistent") } returns emptyFlow()
+        coEvery { raceWeekendRecapRepository.saveRaceWeekendRecap(any()) } just Runs
+
+        val result = raceWeekendService.generateRaceRecap(listOf("nonexistent"))
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { genAIService.generateRaceRecap(any()) }
+    }
+
+    @Test
+    fun `generateRaceRecap should continue processing other races when one fails`() = runTest {
+        val race = createRaceWeekend(raceId = "race-2", raceName = "British Grand Prix", openF1MeetingKey = 200)
+
+        coEvery { raceRepository.getRaceById("race-1") } returns emptyFlow()
+        coEvery { raceRepository.getRaceById("race-2") } returns flowOf(race)
+        coEvery { genAIService.generateRaceRecap("British Grand Prix") } returns flowOf("Recap Britain")
+        coEvery { raceWeekendRecapRepository.saveRaceWeekendRecap(any()) } just Runs
+
+        val result = raceWeekendService.generateRaceRecap(listOf("race-1", "race-2"))
+
+        assertEquals(1, result.size)
+        assertEquals("race-2", result[0])
+    }
+
+    @Test
+    fun `generateRaceRecap should return empty list when no races provided`() = runTest {
+        val result = raceWeekendService.generateRaceRecap(emptyList())
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { genAIService.generateRaceRecap(any()) }
+        coVerify(exactly = 0) { raceWeekendRecapRepository.saveRaceWeekendRecap(any()) }
     }
 }

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/task/NotificationsTaskTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/task/NotificationsTaskTest.kt
@@ -44,8 +44,7 @@ class NotificationsTaskTest {
             createdAt = Clock.System.now(),
             updatedAt = Clock.System.now(),
             version = 1,
-            results = emptyList(),
-            summaryParagraphs = null
+            results = emptyList()
         )
     }
 

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/task/TeamsResultsCalculatorTaskTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/task/TeamsResultsCalculatorTaskTest.kt
@@ -73,8 +73,7 @@ class TeamsResultsCalculatorTaskTest {
         results = listOf(
             RaceWeekendResult.Companion.Result("id-VER", 1, "VER", 20.0),
             RaceWeekendResult.Companion.Result("id-HAM", 44, "HAM", 15.0)
-        ),
-        summaryParagraphs = null
+        )
     )
 
     private fun createTeam(id: String) = Team(


### PR DESCRIPTION
## Summary

- Extend the `/admin/race-weekends/recap` endpoint response to include the actual AI-generated recap content, not just the processed race IDs
- Add `RecapEntry` nested type with `raceId`, `raceName`, and `recapParagraphs`
- Add `recaps: List<RecapEntry>` field alongside the existing `recapIds` array

## Changes

| File | Change |
|------|--------|
| `GenerateRaceRecapResponse.kt` | Added `RecapEntry` nested data class + `recaps` field |
| `RaceWeekendService.kt` | Return type changed from `List<String>` → `List<RaceWeekendRecap>` |
| `RaceWeekendServiceImpl.kt` | Collects full `RaceWeekendRecap` objects instead of just IDs |
| `AdminOperationsController.kt` | Maps recaps to `RecapEntry` DTOs in response |
| `AdminOperationsControllerTest.kt` | Updated mocks and assertions for new response shape |
| `RaceWeekendServiceTest.kt` | Updated assertions to access `RaceWeekendRecap` properties |

## API Response (before → after)

**Before:**
```json
{ "recapIds": ["race-1", "race-2"] }
```

**After:**
```json
{
  "recapIds": ["race-1", "race-2"],
  "recaps": [
    { "raceId": "race-1", "raceName": "Monaco Grand Prix", "recapParagraphs": ["Paragraph 1", "Paragraph 2"] },
    { "raceId": "race-2", "raceName": "British Grand Prix", "recapParagraphs": ["Paragraph A"] }
  ]
}
```

## Testing

- All existing tests updated and passing
- Full build (`./gradlew build`) passes cleanly