### PR TITLE
feat: add OpenAPI docs with Swagger UI and initial RBAC support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 val firebaseAdminVersion = "9.8.0"
-val kotlinxDateTimeVersion = "0.8.0-rc02-0.6.x-compat"
+val kotlinxDateTimeVersion = "0.7.1"
 val caffeineVersion = "3.2.4"
 val googleGenAIVersion = "1.52.0"
 val okhttp3Version = "5.3.2"
@@ -44,6 +44,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion")
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
     implementation("com.google.genai:google-genai:$googleGenAIVersion")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.3")
     runtimeOnly("io.micrometer:micrometer-registry-influx")
     testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
     testImplementation("org.springframework.boot:spring-boot-starter-quartz-test")
@@ -67,4 +68,32 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+configurations.all {
+    fun isNonStable(version: String): Boolean {
+        val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
+        val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+        val isStable = stableKeyword || regex.matches(version)
+        return isStable.not()
+    }
+
+    fun isRC(version: String): Boolean {
+        return version.uppercase().contains("RC")
+    }
+
+    tasks.named("dependencyUpdates").configure {
+        resolutionStrategy {
+            componentSelection {
+                all {
+                    if (isNonStable(candidate.version) && !isNonStable(version.toString())) {
+                        reject("Release candidate")
+                    }
+                    if (isRC(candidate.version)) {
+                        reject("Release candidate")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/collections/Fanta F1 backend/Update drivers costs.yml
+++ b/collections/Fanta F1 backend/Update drivers costs.yml
@@ -5,35 +5,12 @@ info:
 
 http:
   method: POST
-  url: "{{baseUrl}}/admin/drivers/costs"
+  url: "{{baseUrl}}/drivers/price"
   body:
     type: json
     data: |-
       {
-        "driversCosts": [
-          { "acronym": "VER", "driverCost": 146.0 },
-          { "acronym": "HAM", "driverCost": 132.0 },
-          { "acronym": "Pia", "driverCost": 114.0 },
-          { "acronym": "Lec", "driverCost": 98.0 },
-          { "acronym": "Nor", "driverCost": 94.0 },
-          { "acronym": "Bot", "driverCost": 72.0 },
-          { "acronym": "Rus", "driverCost": 70.0 },
-          { "acronym": "Ant", "driverCost": 75.0 },
-          { "acronym": "Sai", "driverCost": 57.0 },
-          { "acronym": "Per", "driverCost": 57.0 },
-          { "acronym": "Alo", "driverCost": 56.0 },
-          { "acronym": "Oco", "driverCost": 26.0 },
-          { "acronym": "Gas", "driverCost": 26.0 },
-          { "acronym": "Hul", "driverCost": 24.0 },
-          { "acronym": "Alb", "driverCost": 24.0 },
-          { "acronym": "Had", "driverCost": 22.0 },
-          { "acronym": "Bea", "driverCost": 22.0 },
-          { "acronym": "Str", "driverCost": 17.0 },
-          { "acronym": "Law", "driverCost": 14.0 },
-          { "acronym": "Bor", "driverCost": 8.0 },
-          { "acronym": "Col", "driverCost": 2.0 },
-          { "acronym": "Lin", "driverCost": 2.0 }
-          ]
+        "acronyms": []
       }
   auth: inherit
 

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/configuration/WebfluxSecurityConfiguration.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/configuration/WebfluxSecurityConfiguration.kt
@@ -3,6 +3,7 @@ package net.battaglini.fantaf1appbackend.configuration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.convert.converter.Converter
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.core.GrantedAuthority
@@ -14,12 +15,23 @@ import reactor.core.publisher.Flux
 
 @Configuration
 @EnableWebFluxSecurity
+@EnableReactiveMethodSecurity(useAuthorizationManager = true)
 class WebfluxSecurityConfiguration {
     @Bean
     fun springSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
-        http.authorizeExchange { exchanges ->
-            exchanges.anyExchange().hasRole("admin")
-        }
+        http
+            .authorizeExchange { exchanges ->
+                exchanges
+                    .pathMatchers(
+                        "/docs/**",
+                        "/v1/api-docs/**",
+                        "/swagger-resources/**",
+                        "/webjars/**",
+                        "/swagger-ui/**"
+                    ).permitAll()
+                    .pathMatchers("/actuator/**").permitAll()
+                    .anyExchange().authenticated()
+            }
             .oauth2ResourceServer { resourceServerCustomizer ->
                 resourceServerCustomizer.jwt { jwt ->
                     jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())
@@ -35,7 +47,7 @@ class WebfluxSecurityConfiguration {
         converter.setJwtGrantedAuthoritiesConverter(Converter<Jwt, Flux<GrantedAuthority>> { jwt ->
             val role = jwt.claims["user_role"] as? String
             if (role != null) {
-                Flux.just(SimpleGrantedAuthority("ROLE_$role"))
+                Flux.just(SimpleGrantedAuthority("ROLE_${role.uppercase()}"))
             } else {
                 Flux.empty()
             }

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/DriversController.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/DriversController.kt
@@ -7,6 +7,7 @@ import net.battaglini.fantaf1appbackend.model.response.DriverSummariesResponse
 import net.battaglini.fantaf1appbackend.service.DriverPricingService
 import net.battaglini.fantaf1appbackend.service.DriverService
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping(path = ["/drivers"])
+@PreAuthorize("hasAnyRole('ADMIN', 'DRIVERS_MANAGER')")
 class DriversController(
     private val driverService: DriverService,
     private val driverPricingService: DriverPricingService

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/TeamsController.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/controller/TeamsController.kt
@@ -5,6 +5,7 @@ import net.battaglini.fantaf1appbackend.model.request.CalculateTeamsResultsReque
 import net.battaglini.fantaf1appbackend.model.response.CalculateTeamsResultsResponse
 import net.battaglini.fantaf1appbackend.service.RaceWeekendService
 import net.battaglini.fantaf1appbackend.service.TeamResultsService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping(path = ["/teams"])
+@PreAuthorize("hasAnyRole('ADMIN', 'TEAMS_MANAGER')")
 class TeamsController(
     private val raceWeekendService: RaceWeekendService,
     private val teamResultsService: TeamResultsService

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -30,3 +30,9 @@ results-calculator:
   dry-run: false
 pricing:
   dry-run: true
+
+management:
+  influx:
+    metrics:
+      export:
+        enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,14 @@ spring:
         jwt:
           issuer-uri: ${FANTAF1_AUTH_ISSUER_URI}
 
+springdoc:
+  api-docs:
+    path: /v1/api-docs
+  swagger-ui:
+    path: /docs
+  enable-spring-security: true
+  show-actuator: true
+
 logging:
   level:
     root: info


### PR DESCRIPTION
## Summary

- Add OpenAPI documentation with Swagger UI for API discovery
- Implement initial RBAC (Role-Based Access Control) support
- Restructure admin operations into dedicated controller classes

## Changes

- `build.gradle.kts` — Added OpenAPI/Swagger dependencies
- `WebfluxSecurityConfiguration.kt` — RBAC role checks on endpoints
- `DriversController.kt` — Added RBAC annotations
- `TeamsController.kt` — Added RBAC annotations
- `application.yaml` / `application-local.yaml` — OpenAPI config properties
- CI workflow — Updated YAML formatting

## Next Steps

- Expand RBAC roles as more admin endpoints are added
- Add API documentation for remaining controllers