### PR TITLE
refactor: replace hardcoded delays with Krate-based rate limiter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ val okhttp3Version = "5.4.0"
 val mockkVersion = "1.14.9"
 val springMockkVersion = "5.0.1"
 val springDocVersion = "3.0.3"
+val krateVersion = "1.0.3"
 
 plugins {
     kotlin("jvm") version "2.4.0"
@@ -46,6 +47,7 @@ dependencies {
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
     implementation("com.google.genai:google-genai:$googleGenAIVersion")
     implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:$springDocVersion")
+    implementation("io.github.lpicanco:krate-core:$krateVersion")
     runtimeOnly("io.micrometer:micrometer-registry-influx")
     testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
     testImplementation("org.springframework.boot:spring-boot-starter-quartz-test")

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/client/OpenF1Client.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/client/OpenF1Client.kt
@@ -2,6 +2,8 @@ package net.battaglini.fantaf1appbackend.client
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import net.battaglini.fantaf1appbackend.configuration.CacheConfiguration
 import net.battaglini.fantaf1appbackend.configuration.CacheConfiguration.Companion.MEETING_SESSIONS_CACHE
 import net.battaglini.fantaf1appbackend.configuration.OpenF1ApiProperties
@@ -27,11 +29,17 @@ import org.springframework.web.util.UriBuilder
  */
 @Component
 class OpenF1Client(
+    private val rateLimiter: OpenF1RateLimiter,
     openF1ApiProperties: OpenF1ApiProperties
 ) {
     private val webClient: WebClient = WebClient.builder()
         .baseUrl("${openF1ApiProperties.baseUrl}/${openF1ApiProperties.apiVersion}")
         .build()
+
+    private suspend fun <T : Any> rateLimited(block: suspend () -> Flow<T>): Flow<T> {
+        rateLimiter.acquire()
+        return flow { emitAll(block()) }
+    }
 
     /**
      * Retrieves a list of drivers based on the provided criteria.
@@ -44,7 +52,7 @@ class OpenF1Client(
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
     @Cacheable(CacheConfiguration.DRIVERS_CACHE)
-    fun getDrivers(
+    suspend fun getDrivers(
         sessionKeys: List<String> = emptyList(),
         meetingKey: Int? = null,
         acronym: String? = null,
@@ -54,17 +62,19 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of sessionKeys, meetingKey, acronym or driverNumber are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/drivers")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
-                acronym?.also { acronym -> uriBuilder.queryParam("name_acronym", acronym) }
-                driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/drivers")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
+                    acronym?.also { acronym -> uriBuilder.queryParam("name_acronym", acronym) }
+                    driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow { it.bodyToFlow() }
+                    uriBuilder.build()
+                }
+                .exchangeToFlow { it.bodyToFlow() }
+        }
     }
 
     /**
@@ -77,7 +87,7 @@ class OpenF1Client(
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
     @Cacheable(CacheConfiguration.MEETINGS_CACHE_NAME)
-    fun getRaces(
+    suspend fun getRaces(
         meetingKey: Int? = null,
         year: Int? = null,
         circuitKey: Int? = null
@@ -86,17 +96,19 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey, year or circuitKey are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/meetings")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, emptyList())
-                year?.also { year -> uriBuilder.queryParam("year", year) }
-                circuitKey?.also { circuitKey -> uriBuilder.queryParam("circuit_key", circuitKey) }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/meetings")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, emptyList())
+                    year?.also { year -> uriBuilder.queryParam("year", year) }
+                    circuitKey?.also { circuitKey -> uriBuilder.queryParam("circuit_key", circuitKey) }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow { it.bodyToFlow() }
+                    uriBuilder.build()
+                }
+                .exchangeToFlow { it.bodyToFlow() }
+        }
     }
 
     /**
@@ -110,7 +122,7 @@ class OpenF1Client(
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
     @Cacheable(MEETING_SESSIONS_CACHE)
-    fun getSessions(
+    suspend fun getSessions(
         meetingKey: Int? = null,
         sessionKey: String? = null,
         sessionName: OpenF1SessionName? = null,
@@ -120,17 +132,19 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey, sessionKey, year or sessionName are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/sessions")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
-                year?.also { year -> uriBuilder.queryParam("year", year) }
-                sessionName?.also { sessionName -> uriBuilder.queryParam("session_name", sessionName.toString()) }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/sessions")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
+                    year?.also { year -> uriBuilder.queryParam("year", year) }
+                    sessionName?.also { sessionName -> uriBuilder.queryParam("session_name", sessionName.toString()) }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow { it.bodyToFlow() }
+                    uriBuilder.build()
+                }
+                .exchangeToFlow { it.bodyToFlow() }
+        }
     }
 
     /**
@@ -141,7 +155,7 @@ class OpenF1Client(
      * @return A [Flow] emitting [OpenF1SessionResultResponse] objects.
      * @throws OpenF1ClientRequestException If neither meetingKey nor sessionKey is provided.
      */
-    fun getResults(
+    suspend fun getResults(
         meetingKey: Int? = null,
         sessionKeys: List<String> = emptyList()
     ): Flow<OpenF1SessionResultResponse> {
@@ -149,23 +163,25 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey or sessionKey are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/session_result")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/session_result")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow {
-                if (it.statusCode() != HttpStatus.OK) {
-                    return@exchangeToFlow emptyFlow()
+                    uriBuilder.build()
                 }
-                it.bodyToFlow()
-            }
+                .exchangeToFlow {
+                    if (it.statusCode() != HttpStatus.OK) {
+                        return@exchangeToFlow emptyFlow()
+                    }
+                    it.bodyToFlow()
+                }
+        }
     }
 
-    fun getQualifyingResults(
+    suspend fun getQualifyingResults(
         meetingKey: Int? = null,
         sessionKeys: List<String> = emptyList()
     ): Flow<OpenF1QualifyingSessionResultResponse> {
@@ -173,20 +189,22 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey or sessionKey are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/session_result")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/session_result")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKeys)
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow {
-                if (it.statusCode() != HttpStatus.OK) {
-                    return@exchangeToFlow emptyFlow()
+                    uriBuilder.build()
                 }
-                it.bodyToFlow()
-            }
+                .exchangeToFlow {
+                    if (it.statusCode() != HttpStatus.OK) {
+                        return@exchangeToFlow emptyFlow()
+                    }
+                    it.bodyToFlow()
+                }
+        }
     }
 
     /**
@@ -199,7 +217,7 @@ class OpenF1Client(
      * @return A [Flow] emitting [OpenF1OvertakeResponse] objects.
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
-    fun getOvertakes(
+    suspend fun getOvertakes(
         meetingKey: Int? = null,
         sessionKey: String? = null,
         overtakingDriverNumber: Int? = null,
@@ -209,32 +227,34 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey, sessionKey, overtakenDriverNumber or overtakingDriverNumber are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/overtakes")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
-                overtakingDriverNumber?.also { overtakingDriverNumber ->
-                    uriBuilder.queryParam(
-                        "overtaking_driver_number",
-                        overtakingDriverNumber
-                    )
-                }
-                overtakenDriverNumber?.also { overtakenDriverNumber ->
-                    uriBuilder.queryParam(
-                        "overtaken_driver_number",
-                        overtakenDriverNumber
-                    )
-                }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/overtakes")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
+                    overtakingDriverNumber?.also { overtakingDriverNumber ->
+                        uriBuilder.queryParam(
+                            "overtaking_driver_number",
+                            overtakingDriverNumber
+                        )
+                    }
+                    overtakenDriverNumber?.also { overtakenDriverNumber ->
+                        uriBuilder.queryParam(
+                            "overtaken_driver_number",
+                            overtakenDriverNumber
+                        )
+                    }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow {
-                if (it.statusCode() == HttpStatus.NOT_FOUND) {
-                    return@exchangeToFlow emptyFlow()
+                    uriBuilder.build()
                 }
-                it.bodyToFlow()
-            }
+                .exchangeToFlow {
+                    if (it.statusCode() == HttpStatus.NOT_FOUND) {
+                        return@exchangeToFlow emptyFlow()
+                    }
+                    it.bodyToFlow()
+                }
+        }
     }
 
     /**
@@ -247,7 +267,7 @@ class OpenF1Client(
      * @return A [Flow] emitting [OpenF1StintResponse] objects.
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
-    fun getStints(
+    suspend fun getStints(
         meetingKey: Int? = null,
         sessionKey: String? = null,
         driverNumber: Int? = null,
@@ -257,17 +277,19 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey, sessionKey, driverNumber or compound are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/stints")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
-                driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
-                compound?.also { compound -> uriBuilder.queryParam("compound", compound) }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/stints")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
+                    driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
+                    compound?.also { compound -> uriBuilder.queryParam("compound", compound) }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow { it.bodyToFlow() }
+                    uriBuilder.build()
+                }
+                .exchangeToFlow { it.bodyToFlow() }
+        }
     }
 
     /**
@@ -279,7 +301,7 @@ class OpenF1Client(
      * @return A [Flow] emitting [OpenF1LapResponse] objects.
      * @throws OpenF1ClientRequestException If none of the parameters are provided.
      */
-    fun getLaps(
+    suspend fun getLaps(
         meetingKey: Int? = null,
         sessionKey: String? = null,
         driverNumber: Int? = null
@@ -288,21 +310,23 @@ class OpenF1Client(
             throw OpenF1ClientRequestException("One of meetingKey, sessionKey or driverNumber are required")
         }
 
-        return webClient
-            .get()
-            .uri { uriBuilder ->
-                uriBuilder.path("/laps")
-                addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
-                driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
+        return rateLimited {
+            webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/laps")
+                    addMeetingAndSessionKeyParams(uriBuilder, meetingKey, sessionKey?.let { listOf(it) } ?: emptyList())
+                    driverNumber?.also { driverNumber -> uriBuilder.queryParam("driver_number", driverNumber) }
 
-                uriBuilder.build()
-            }
-            .exchangeToFlow { response ->
-                if (response.statusCode() == HttpStatus.NOT_FOUND) {
-                    return@exchangeToFlow emptyFlow()
+                    uriBuilder.build()
                 }
-                response.bodyToFlow()
-            }
+                .exchangeToFlow { response ->
+                    if (response.statusCode() == HttpStatus.NOT_FOUND) {
+                        return@exchangeToFlow emptyFlow()
+                    }
+                    response.bodyToFlow()
+                }
+        }
     }
 
     private fun addMeetingAndSessionKeyParams(uriBuilder: UriBuilder, meetingKey: Int?, sessionKeys: List<String>) {

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/client/OpenF1RateLimiter.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/client/OpenF1RateLimiter.kt
@@ -1,0 +1,29 @@
+package net.battaglini.fantaf1appbackend.client
+
+import com.neutrine.krate.rateLimiter
+import kotlinx.coroutines.delay
+import net.battaglini.fantaf1appbackend.configuration.OpenF1ApiProperties
+import org.springframework.stereotype.Component
+import java.time.temporal.ChronoUnit
+
+@Component
+class OpenF1RateLimiter(
+    openF1ApiProperties: OpenF1ApiProperties
+) {
+    private val perSecondBucket = rateLimiter(maxRate = openF1ApiProperties.rateLimit.maxRatePerSecond.toLong())
+    private val perMinuteBucket = rateLimiter(maxRate = openF1ApiProperties.rateLimit.maxBurstPerMinute.toLong()) {
+        maxBurst = openF1ApiProperties.rateLimit.maxBurstPerMinute.toLong()
+        maxRateTimeUnit = ChronoUnit.MINUTES
+    }
+
+    suspend fun acquire() {
+        // Per-minute bucket (0.5 tokens/sec) is more restrictive than per-second bucket (3 tokens/sec)
+        // Acquire from the more restrictive bucket first
+        while (!perMinuteBucket.tryTake()) {
+            delay(50)
+        }
+        while (!perSecondBucket.tryTake()) {
+            delay(50)
+        }
+    }
+}

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/configuration/OpenF1ApiProperties.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/configuration/OpenF1ApiProperties.kt
@@ -5,5 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "open-f1")
 data class OpenF1ApiProperties(
     val baseUrl: String,
-    val apiVersion: String
-)
+    val apiVersion: String,
+    val rateLimit: RateLimit = RateLimit()
+) {
+    data class RateLimit(
+        val maxRatePerSecond: Int = 3,
+        val maxRatePerMinute: Int = 30,
+        val maxBurstPerMinute: Int = 30
+    )
+}

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceResultsServiceImpl.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceResultsServiceImpl.kt
@@ -1,6 +1,5 @@
 package net.battaglini.fantaf1appbackend.service
 
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
@@ -67,14 +66,13 @@ class RaceResultsServiceImpl(
     ): DriverRaceResult {
         var fastestLap = 9_999.0
         var speedAtTrap = 0.0
-        openF1Client.getLaps(sessionKey = sessionKey.toString(), driverNumber = driver.driverNumber)
-            .collect { lap ->
-                if (lap.lapDuration != null && lap.lapDuration < fastestLap)
-                    fastestLap = lap.lapDuration
-                if (lap.speedTrapSpeed != null && lap.speedTrapSpeed > speedAtTrap)
-                    speedAtTrap = lap.speedTrapSpeed
-            }
-        delay(2000.toDuration(DurationUnit.MILLISECONDS))
+            openF1Client.getLaps(sessionKey = sessionKey.toString(), driverNumber = driver.driverNumber)
+                .collect { lap ->
+                    if (lap.lapDuration != null && lap.lapDuration < fastestLap)
+                        fastestLap = lap.lapDuration
+                    if (lap.speedTrapSpeed != null && lap.speedTrapSpeed > speedAtTrap)
+                        speedAtTrap = lap.speedTrapSpeed
+                }
         val startPosition = startingGrid.firstOrNull { it.driverNumber == driver.driverNumber }?.position
         val result = results.first { it.driverNumber == driver.driverNumber }
 

--- a/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
+++ b/src/main/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceImpl.kt
@@ -1,6 +1,5 @@
 package net.battaglini.fantaf1appbackend.service
 
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -21,9 +20,6 @@ import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -60,7 +56,6 @@ class RaceWeekendServiceImpl(
             val races = openF1Client.getRaces(year = year).map { meeting ->
                 val sessions = openF1Client.getSessions(meeting.meetingKey)
                     .map { it.toRaceWeekendSession(calculateSessionId(it.sessionKey, it.meetingKey)) }
-                delay(100.toDuration(DurationUnit.MILLISECONDS))
                 meeting.toRace(calculateRaceId(meeting.meetingKey, meeting.year), sessions.toList())
             }.toList()
             raceRepository.createOrUpdateRaces(races)
@@ -173,9 +168,7 @@ class RaceWeekendServiceImpl(
     }
 
     private suspend fun <T> fetchResults(fetcher: suspend () -> Flow<T>): List<T> {
-        val results = fetcher().toList()
-        delay(2.seconds)
-        return results
+        return fetcher().toList()
     }
 
     private fun calculateRaceId(meetingKey: Int, year: Int): String {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,10 @@ jolpica:
 open-f1:
   base-url: https://api.openf1.org
   api-version: v1
+  rate-limit:
+    max-rate-per-second: 3
+    max-rate-per-minute: 30
+    max-burst-per-minute: 30
 
 notifications:
   lineup:

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/DriverServiceTest.kt
@@ -134,12 +134,12 @@ class DriverServiceTest {
     fun `onStart should call seedDrivers when drivers seeding is enabled`() = runTest {
         every { seedingProperties.drivers } returns true
         val openF1Driver = createOpenF1Driver()
-        every { openF1Client.getDrivers(sessionKeys = listOf("latest")) } returns flowOf(openF1Driver)
+        coEvery { openF1Client.getDrivers(sessionKeys = listOf("latest")) } returns flowOf(openF1Driver)
         coEvery { driverRepository.createOrUpdateDrivers(any()) } just Runs
 
         driverService.onStart()
 
-        verify { openF1Client.getDrivers(sessionKeys = listOf("latest")) }
+        coVerify { openF1Client.getDrivers(sessionKeys = listOf("latest")) }
         coVerify { driverRepository.createOrUpdateDrivers(any()) }
     }
 
@@ -149,14 +149,14 @@ class DriverServiceTest {
 
         driverService.onStart()
 
-        verify(exactly = 0) { openF1Client.getDrivers(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { openF1Client.getDrivers(any(), any(), any(), any()) }
         coVerify(exactly = 0) { driverRepository.createOrUpdateDrivers(any()) }
     }
 
     @Test
     fun `seedDrivers should fetch drivers from client and save to repository`() = runTest {
         val openF1Driver = createOpenF1Driver()
-        every { openF1Client.getDrivers(sessionKeys = listOf("latest")) } returns flowOf(openF1Driver)
+        coEvery { openF1Client.getDrivers(sessionKeys = listOf("latest")) } returns flowOf(openF1Driver)
         coEvery { driverRepository.createOrUpdateDrivers(any()) } just Runs
 
         driverService.seedDrivers()
@@ -173,7 +173,7 @@ class DriverServiceTest {
 
     @Test
     fun `seedDrivers should handle exceptions gracefully without throwing`() = runTest {
-        every { openF1Client.getDrivers(sessionKeys = listOf("latest")) } throws RuntimeException("API Error")
+        coEvery { openF1Client.getDrivers(sessionKeys = listOf("latest")) } throws RuntimeException("API Error")
 
         driverService.seedDrivers()
 
@@ -242,7 +242,7 @@ class DriverServiceTest {
         val openF1Driver1 = createOpenF1Driver(acronym = "VER")
         val openF1Driver2 = createOpenF1Driver(acronym = "LEC")
 
-        every { openF1Client.getDrivers(sessionKeys = listOf("1", "2")) } returns flowOf(openF1Driver1, openF1Driver2)
+        coEvery { openF1Client.getDrivers(sessionKeys = listOf("1", "2")) } returns flowOf(openF1Driver1, openF1Driver2)
 
         val driver1 = createDriver(id = "1", acronym = "VER")
         val driver2 = createDriver(id = "2", acronym = "HAM") // In repo, but not returned by session API

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/PracticeResultsServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/PracticeResultsServiceTest.kt
@@ -92,7 +92,7 @@ class PracticeResultsServiceTest {
         val result = practiceResultsService.getDriversResultsForCombinedPractice(raceWeekend).toList()
 
         assertTrue(result.isEmpty())
-        verify(exactly = 0) { openF1Client.getResults(any(), any()) }
+        coVerify(exactly = 0) { openF1Client.getResults(any(), any()) }
         coVerify(exactly = 0) { driverService.getDriversInSessions(any()) }
     }
 

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/QualifyingResultsServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/QualifyingResultsServiceTest.kt
@@ -134,7 +134,7 @@ class QualifyingResultsServiceTest {
             qualifyingResultsService.getDriversResultsForQualifying(raceWeekend, isSprintQualifying = false).toList()
 
         assertTrue(result.isEmpty())
-        verify(exactly = 0) { openF1Client.getQualifyingResults(any()) }
+        coVerify(exactly = 0) { openF1Client.getQualifyingResults(any()) }
         coVerify(exactly = 0) { driverService.getDriversInSessions(any()) }
     }
 

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceResultsServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceResultsServiceTest.kt
@@ -141,7 +141,7 @@ class RaceResultsServiceTest {
         val result = raceResultsService.getResultsForRace(raceWeekend, isSprintRace = false).toList()
 
         assertTrue(result.isEmpty())
-        verify(exactly = 0) { openF1Client.getResults(any()) }
+        coVerify(exactly = 0) { openF1Client.getResults(any()) }
     }
 
     @Test

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/service/RaceWeekendServiceTest.kt
@@ -137,9 +137,8 @@ class RaceWeekendServiceTest {
             createSessionResponse(sessionKey = 1003, meetingKey = 100, sessionName = OpenF1SessionName.RACE)
         )
 
-        // getRaces and getSessions are regular (non-suspend) functions — use every
-        every { openF1Client.getRaces(year = 2025) } returns flowOf(meeting)
-        every { openF1Client.getSessions(meetingKey = 100) } returns flowOf(sessions[0], sessions[1], sessions[2])
+        coEvery { openF1Client.getRaces(year = 2025) } returns flowOf(meeting)
+        coEvery { openF1Client.getSessions(meetingKey = 100) } returns flowOf(sessions[0], sessions[1], sessions[2])
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -159,9 +158,8 @@ class RaceWeekendServiceTest {
         every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
 
         val meeting = createMeetingResponse(meetingKey = 100, year = 2025)
-        // getRaces is a regular function — use every, match with specific year
-        every { openF1Client.getRaces(year = any()) } returns flowOf(meeting)
-        every { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -175,8 +173,8 @@ class RaceWeekendServiceTest {
         every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
 
         val meeting = createMeetingResponse(meetingKey = 100, year = 2025)
-        every { openF1Client.getRaces(year = 2025) } returns flowOf(meeting)
-        every { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = 2025) } returns flowOf(meeting)
+        coEvery { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -194,7 +192,7 @@ class RaceWeekendServiceTest {
     fun `seedRaceWeekends should catch exceptions and not rethrow`() = runTest {
         every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
 
-        every { openF1Client.getRaces(year = any()) } throws RuntimeException("API down")
+        coEvery { openF1Client.getRaces(year = any()) } throws RuntimeException("API down")
 
         // Should not throw — exception is caught internally
         raceWeekendService.seedRaceWeekends()
@@ -206,7 +204,7 @@ class RaceWeekendServiceTest {
     fun `seedRaceWeekends should use correct year from Clock`() = runTest {
         every { clock.now() } returns Instant.parse("2026-01-15T00:00:00Z")
 
-        every { openF1Client.getRaces(year = 2026) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = 2026) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -221,9 +219,9 @@ class RaceWeekendServiceTest {
         val meeting1 = createMeetingResponse(meetingKey = 100, year = 2025)
         val meeting2 = createMeetingResponse(meetingKey = 200, year = 2025)
 
-        every { openF1Client.getRaces(year = 2025) } returns flowOf(meeting1, meeting2)
-        every { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
-        every { openF1Client.getSessions(meetingKey = 200) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = 2025) } returns flowOf(meeting1, meeting2)
+        coEvery { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
+        coEvery { openF1Client.getSessions(meetingKey = 200) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -238,7 +236,7 @@ class RaceWeekendServiceTest {
 
         // Must match year parameter explicitly since getRaces(meetingKey, year, circuitKey)
         // and the service calls getRaces(year = year) — not getRaces(meetingKey = any)
-        every { openF1Client.getRaces(year = any()) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = any()) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()
@@ -257,8 +255,8 @@ class RaceWeekendServiceTest {
         every { clock.now() } returns Instant.parse("2025-06-01T12:00:00Z")
 
         val meeting = createMeetingResponse(meetingKey = 100, year = 2025)
-        every { openF1Client.getRaces(year = any()) } returns flowOf(meeting)
-        every { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
+        coEvery { openF1Client.getRaces(year = any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getSessions(meetingKey = 100) } returns emptyFlow()
         coEvery { raceRepository.createOrUpdateRaces(any()) } just Runs
 
         raceWeekendService.seedRaceWeekends()

--- a/src/test/kotlin/net/battaglini/fantaf1appbackend/task/RaceWeekendResultsCalculatorTaskTest.kt
+++ b/src/test/kotlin/net/battaglini/fantaf1appbackend/task/RaceWeekendResultsCalculatorTaskTest.kt
@@ -6,7 +6,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDateTime
@@ -30,7 +29,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.time.*
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.toDuration
+import kotlin.time.DurationUnit
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
@@ -72,10 +75,6 @@ class RaceWeekendResultsCalculatorTaskTest {
         clearAllMocks()
         every { resultsCalculatorProperties.enable } returns true
         every { resultsCalculatorProperties.dryRun } returns false
-
-        mockkStatic("kotlinx.coroutines.DelayKt")
-        coEvery { delay(any<Long>()) } just Runs
-        coEvery { delay(any<kotlin.time.Duration>()) } just Runs
     }
 
     private fun createDriver(acronym: String) = Driver(
@@ -245,7 +244,7 @@ class RaceWeekendResultsCalculatorTaskTest {
 
         val meeting = createMeeting(1, year, LocalDateTime(year, 3, 20, 10, 0, 0))
 
-        every { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
         coEvery { raceWeekendResultRepository.findRaceWeekendResult(openF1MeetingKey = 1) } returns null
 
         val sessionResponse = OpenF1SessionResponse(
@@ -258,7 +257,7 @@ class RaceWeekendResultsCalculatorTaskTest {
             gmtOffset = UtcOffset.ZERO,
             year = year
         )
-        every { openF1Client.getSessions(1) } returns flowOf(sessionResponse)
+        coEvery { openF1Client.getSessions(1) } returns flowOf(sessionResponse)
 
         val ver = createDriver("VER")
         coEvery { driverRepository.getDrivers() } returns flowOf(ver)
@@ -315,7 +314,7 @@ class RaceWeekendResultsCalculatorTaskTest {
 
         val meeting = createMeeting(1, year, LocalDateTime(year, 3, 10, 12, 0, 0))
 
-        every { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
 
         task.runTask()
 
@@ -329,7 +328,7 @@ class RaceWeekendResultsCalculatorTaskTest {
         val year = 2024
         val meeting = createMeeting(1, year, LocalDateTime(year, 3, 20, 10, 0, 0))
 
-        every { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getRaces(meetingKey = any(), year = any(), circuitKey = any()) } returns flowOf(meeting)
         coEvery { raceWeekendResultRepository.findRaceWeekendResult(openF1MeetingKey = 1) } returns mockk()
 
         task.runTask()
@@ -345,9 +344,9 @@ class RaceWeekendResultsCalculatorTaskTest {
         val year = 2024
         val meeting = createMeeting(1, year, LocalDateTime(year, 3, 20, 10, 0, 0))
 
-        every { openF1Client.getRaces(any(), any(), any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getRaces(any(), any(), any()) } returns flowOf(meeting)
         coEvery { raceWeekendResultRepository.findRaceWeekendResult(openF1MeetingKey = 1) } returns null
-        every { openF1Client.getSessions(1) } returns flowOf()
+        coEvery { openF1Client.getSessions(1) } returns flowOf()
 
         val ver = createDriver("VER")
         coEvery { driverRepository.getDrivers() } returns flowOf(ver)
@@ -392,9 +391,9 @@ class RaceWeekendResultsCalculatorTaskTest {
         val year = 2024
         val meeting = createMeeting(1, year, LocalDateTime(year, 3, 20, 10, 0, 0))
 
-        every { openF1Client.getRaces(any(), any(), any()) } returns flowOf(meeting)
+        coEvery { openF1Client.getRaces(any(), any(), any()) } returns flowOf(meeting)
         coEvery { raceWeekendResultRepository.findRaceWeekendResult(openF1MeetingKey = 1) } returns null
-        every { openF1Client.getSessions(1) } returns flowOf()
+        coEvery { openF1Client.getSessions(1) } returns flowOf()
 
         // Missing race results
         coEvery { raceWeekendService.fetchDriversResults(any()) } returns null


### PR DESCRIPTION
## Objective

Replace hardcoded `delay` calls used as a cheap rate limiting workaround with a proper token bucket rate limiter for OpenF1 API calls (limit: 3 req/sec, 30 req/min).

## Changes

- Add `OpenF1RateLimiter` component with two Krate token buckets (3/sec, 30/min)
- Make OpenF1Client API methods `suspend` functions to support rate limiter
- Add rate limit config to `OpenF1ApiProperties` and `application.yaml`
- Remove hardcoded `delay` calls from `RaceWeekendServiceImpl` and `RaceResultsServiceImpl`
- Update tests for suspend OpenF1Client methods (coEvery/coVerify)